### PR TITLE
Endre lenke til å gå til resilient web designs hjemmeside

### DIFF
--- a/09-ressurser/cover.md
+++ b/09-ressurser/cover.md
@@ -8,7 +8,7 @@ Noen har kanskje blitt nevnt andre steder i gitbooken, men for oversiktens skyld
 
 > Vi lenker til nettressurser der disse finnes, men de vil som regel også være tilgjengelige på din favoritt-podcastplattform.
 
-* [Resilient Web Design](https://podfanatic.com/podcast/resilient-web-design) om webens historie, viktigheten av å lære av fortiden for å bli bedre forberedt på fremtiden. **Veldig anbefalt!!**
+* [Resilient Web Design](https://resilientwebdesign.com/) om webens historie, viktigheten av å lære av fortiden for å bli bedre forberedt på fremtiden. **Veldig anbefalt!!**
 * [BartJS](https://soundcloud.com/bartjs) om JavaScript
 
 ## Bøker

--- a/09-ressurser/cover.md
+++ b/09-ressurser/cover.md
@@ -8,7 +8,7 @@ Noen har kanskje blitt nevnt andre steder i gitbooken, men for oversiktens skyld
 
 > Vi lenker til nettressurser der disse finnes, men de vil som regel også være tilgjengelige på din favoritt-podcastplattform.
 
-* [Resilient Web Design](https://resilientwebdesign.com/) om webens historie, viktigheten av å lære av fortiden for å bli bedre forberedt på fremtiden. **Veldig anbefalt!!**
+* [Resilient Web Design](https://resilientwebdesign.com/#audio) om webens historie, viktigheten av å lære av fortiden for å bli bedre forberedt på fremtiden. **Veldig anbefalt!!**
 * [BartJS](https://soundcloud.com/bartjs) om JavaScript
 
 ## Bøker


### PR DESCRIPTION
På denne siden får man enkle linker for å abonnere på podcasten. Her kan man også lese kapitlene som bøker, og så var den ganske fin da :smile:

Det kan godt hende dere har vurdert å lenke til denne siden, og valgte podfanatic istedenfor. I så fall kan dere bare ta løpefart og ignorere pull requesten, men jeg synes i hvert fall denne hjemmesiden var nyttigere enn podfanatic, siden jeg svææært sjelden hører på podcasts i nettleseren 😉 